### PR TITLE
Fix failing specs

### DIFF
--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -160,6 +160,38 @@ describe Ubl2Cii::Document do
         expect(document.attribute_at("//#{PREFIX_CBC}:NonExistingElement/Child", 'attr')).to be_nil
       end
     end
+
+    describe '#object_at' do
+      it 'returns a new object if node exists at path' do
+        party = document.object_at("//#{PREFIX_CAC}:AccountingSupplierParty//#{PREFIX_CAC}:Party", described_class)
+        expect(party).to be_a(described_class)
+        expect(party.content_at(".//#{PREFIX_CBC}:Name")).to eq('Supplier Name')
+      end
+
+      it 'returns nil for non-existing path' do
+        party = document.object_at("//#{PREFIX_CAC}:NonExistingElement", described_class)
+        expect(party).to be_nil
+      end
+    end
+
+    describe '#map_nodes' do
+      it 'maps nodes to objects' do
+        lines = document.map_nodes("//#{PREFIX_CAC}:InvoiceLine") do |node|
+          described_class.new_from_node(node, document.namespaces)
+        end
+        expect(lines.size).to eq(2)
+        expect(lines).to all(be_a(described_class))
+        expect(lines.first.content_at(".//#{PREFIX_CBC}:ID")).to eq('1')
+        expect(lines.last.content_at(".//#{PREFIX_CBC}:ID")).to eq('2')
+      end
+
+      it 'returns empty array for non-existing path' do
+        lines = document.map_nodes("//#{PREFIX_CAC}:NonExistingElement") do |node|
+          described_class.new_from_node(node, document.namespaces)
+        end
+        expect(lines).to be_empty
+      end
+    end
   end
 
   describe '.new_from_node' do

--- a/spec/mapper/cii_spec.rb
+++ b/spec/mapper/cii_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Ubl2Cii::Mapper::Cii do
+  let(:document) { instance_double(Ubl2Cii::Document) }
+  let(:xml_builder) { Nokogiri::XML::Builder.new }
+
+  subject { described_class.new }
+
+  describe '#process' do
+    before do
+      allow(document).to receive(:content_at).with('//cbc:CustomizationID').and_return('urn:cen.eu:en16931:2017')
+      allow(document).to receive(:content_at).with('//cbc:ID').and_return('INV-001')
+      allow(document).to receive(:content_at).with('//cbc:InvoiceTypeCode').and_return('380')
+      allow(document).to receive(:content_at).with('//cbc:IssueDate').and_return('2023-01-01')
+      allow(document).to receive(:content_at).with('//cbc:Note').and_return('Test note')
+    end
+
+    it 'builds the XML structure correctly' do
+      subject.process(xml_builder, document)
+      xml = xml_builder.to_xml
+
+      expect(xml).to include('<rsm:ExchangedDocumentContext>')
+      expect(xml).to include('<ram:GuidelineSpecifiedDocumentContextParameter>')
+      expect(xml).to include('<ram:ID>urn:cen.eu:en16931:2017</ram:ID>')
+      expect(xml).to include('<rsm:ExchangedDocument>')
+      expect(xml).to include('<ram:ID>INV-001</ram:ID>')
+      expect(xml).to include('<ram:TypeCode>380</ram:TypeCode>')
+      expect(xml).to include('<ram:IssueDateTime>')
+      expect(xml).to include('<udt:DateTimeString format="102">20230101</udt:DateTimeString>')
+      expect(xml).to include('<ram:IncludedNote>')
+      expect(xml).to include('<ram:Content>Test note</ram:Content>')
+    end
+  end
+end

--- a/spec/mapper/dsl_spec.rb
+++ b/spec/mapper/dsl_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Ubl2Cii::Mapper::Dsl do
+  let(:document) { instance_double(Ubl2Cii::Document) }
+  let(:xml_builder) { Nokogiri::XML::Builder.new }
+
+  subject { described_class.new }
+
+  describe '#process' do
+    before do
+      allow(document).to receive(:content_at).with('//cbc:CustomizationID').and_return('urn:cen.eu:en16931:2017')
+      allow(document).to receive(:content_at).with('//cbc:ID').and_return('INV-001')
+      allow(document).to receive(:content_at).with('//cbc:InvoiceTypeCode').and_return('380')
+      allow(document).to receive(:content_at).with('//cbc:IssueDate').and_return('2023-01-01')
+      allow(document).to receive(:content_at).with('//cbc:Note').and_return('Test note')
+    end
+
+    it 'builds the XML structure correctly' do
+      subject.process(xml_builder, document)
+      xml = xml_builder.to_xml
+
+      expect(xml).to include('<rsm:ExchangedDocumentContext>')
+      expect(xml).to include('<ram:GuidelineSpecifiedDocumentContextParameter>')
+      expect(xml).to include('<ram:ID>urn:cen.eu:en16931:2017</ram:ID>')
+      expect(xml).to include('<rsm:ExchangedDocument>')
+      expect(xml).to include('<ram:ID>INV-001</ram:ID>')
+      expect(xml).to include('<ram:TypeCode>380</ram:TypeCode>')
+      expect(xml).to include('<ram:IssueDateTime>')
+      expect(xml).to include('<udt:DateTimeString format="102">20230101</udt:DateTimeString>')
+      expect(xml).to include('<ram:IncludedNote>')
+      expect(xml).to include('<ram:Content>Test note</ram:Content>')
+    end
+  end
+end

--- a/spec/ubl2cii_spec.rb
+++ b/spec/ubl2cii_spec.rb
@@ -29,7 +29,35 @@ describe Ubl2Cii do
     end
 
     describe "#convert_to_cii" do
+      let(:cii_xml) { converter.convert_to_cii }
 
+      it "converts UBL to CII format" do
+        expect(cii_xml).to include('xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"')
+        expect(cii_xml).to include("<ID>INVOICE-001</ID>")
+      end
+
+      context "with additional elements" do
+        let(:ubl_xml) do
+          <<~XML
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+              <cbc:ID>INVOICE-002</cbc:ID>
+              <cbc:IssueDate>2023-01-01</cbc:IssueDate>
+              <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+              <cbc:Note>Test note</cbc:Note>
+            </Invoice>
+          XML
+        end
+
+        it "maps additional elements correctly" do
+          expect(cii_xml).to include("<ram:ID>INVOICE-002</ram:ID>")
+          expect(cii_xml).to include("<ram:TypeCode>380</ram:TypeCode>")
+          expect(cii_xml).to include("<ram:IssueDateTime><udt:DateTimeString format=\"102\">20230101</udt:DateTimeString></ram:IssueDateTime>")
+          expect(cii_xml).to include("<ram:IncludedNote><ram:Content>Test note</ram:Content></ram:IncludedNote>")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fix failing specs and add missing tests for `Ubl2Cii` classes.

* **`spec/document_spec.rb`**
  - Add tests for `#object_at` method to check for existing and non-existing paths.
  - Add tests for `#map_nodes` method to map nodes to objects and handle non-existing paths.

* **`spec/ubl2cii_spec.rb`**
  - Add tests for `#convert_to_cii` method to verify conversion of UBL to CII format.
  - Add context to test mapping of additional elements.

* **`spec/mapper/cii_spec.rb`**
  - Add tests for `Ubl2Cii::Mapper::Cii` class to verify XML structure building.

* **`spec/mapper/dsl_spec.rb`**
  - Add tests for `Ubl2Cii::Mapper::Dsl` class to verify XML structure building.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hendrixfan/ubl2cii/pull/1?shareId=51b40b42-5f84-4b22-8bc7-5d5835c13f2f).