### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Publish Gem
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/hendrixfan/ubl2cii/security/code-scanning/2](https://github.com/hendrixfan/ubl2cii/security/code-scanning/2)

To fix the problem, you should add a `permissions:` block to the workflow (or job) specifying the minimal set of permissions needed. For a workflow that publishes a gem and interacts with GitHub releases, usually only `contents: read` is needed, unless you are also creating releases or modifying pull requests/issues. In this case, the workflow checks out code and runs an external action to publish to RubyGems, but does not appear to require write access to repository contents or metadata. The best fix is to add:

```yaml
permissions:
  contents: read
```

at the root of the workflow file (`.github/workflows/publish.yml`), just after the `name:` line and before the `on:` block. This ensures all jobs default to the lowest necessary privilege unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Enhancements:
- Add permissions: contents: read at the root of .github/workflows/publish.yml to restrict workflow privileges